### PR TITLE
convert clacheck.py to python3

### DIFF
--- a/OpenSSL-Query/Makefile.PL
+++ b/OpenSSL-Query/Makefile.PL
@@ -5,7 +5,7 @@ use inc::Module::Install;
 
 name        'OpenSSL-Query';
 module_name 'OpenSSL::Query';
-version     '1.1';
+version     '1.2';
 abstract    '';
 author      q{Richard Levitte <levitte@openssl.org>};
 license     'apache';

--- a/OpenSSL-Query/lib/OpenSSL/Query.pm
+++ b/OpenSSL-Query/lib/OpenSSL/Query.pm
@@ -148,4 +148,13 @@ sub has_cla {
 		  @_);
 }
 
+sub list_clas {
+  my $self = shift;
+
+  $self->_perform('cla',
+		  sub { my $obj = shift;
+			return $obj->list_clas(@_) },
+		  @_);
+}
+
 1;

--- a/OpenSSL-Query/lib/OpenSSL/Query/ClaREST.pm
+++ b/OpenSSL-Query/lib/OpenSSL/Query/ClaREST.pm
@@ -41,4 +41,13 @@ sub has_cla {
   return $json->code == 200;
 }
 
+sub list_clas {
+  my $self = shift;
+
+  my $ua = $self->_clahandler;
+  my $json = $ua->get($self->base_url . '/0/CLAs');
+  croak "Server error: ", $json->message if is_server_error($json->code);
+  return $json->code == 200;
+}
+
 1;

--- a/OpenSSL-Query/t/query.t
+++ b/OpenSSL-Query/t/query.t
@@ -11,7 +11,7 @@ use Test::More;
 use OpenSSL::Query::REST;
 use Data::Dumper;
 
-plan tests => 15;
+plan tests => 16;
 
 SKIP: {
   my $query;
@@ -132,6 +132,13 @@ SKIP: {
     plan tests => 1;
     my @res = $query->members_of( 'couchpotatoes' );
     ok( !@res, 'No members in "couchpotatoes"' );
+    note( @res );
+  };
+
+  subtest 'Request all existing CLAs' => sub {
+    plan tests => 1;
+    my @res = $query->list_clas();
+    ok( @res, 'We got CLAs' );
     note( @res );
   };
 

--- a/QueryApp/Makefile.PL
+++ b/QueryApp/Makefile.PL
@@ -4,7 +4,7 @@ use warnings;
 use inc::Module::Install;
 
 name     'QueryApp';
-version  '2.0';
+version  '2.1';
 abstract 'An OpenSSL query web app';
 author   q{Richard Levitte <levitte@openssl.org>};
 license  'apache';

--- a/QueryApp/bin/query.psgi
+++ b/QueryApp/bin/query.psgi
@@ -155,6 +155,14 @@ get '/HasCLA/:id' => sub {
   }
 };
 
+get '/CLAs' => sub {
+  my $query = OpenSSL::Query->new(omc => config->{omc});
+  my @response = $query->list_clas();
+
+  return [ @response ] if @response;
+  send_error('Not found', HTTP_NO_CONTENT);
+};
+
 # End of version 0 API.  To create a new version, start with `prefix '1';'
 # below.
 

--- a/QueryApp/bin/query.psgi
+++ b/QueryApp/bin/query.psgi
@@ -142,6 +142,23 @@ get '/Group/:group/Members' => sub {
   send_error('Not found', HTTP_NO_CONTENT);
 };
 
+get '/Group/:group/CLAs' => sub {
+  my $query = OpenSSL::Query->new(omc => config->{omc}, REST => 0);
+  my $group = uri_decode(param('group'));
+  my @response = ();
+
+  foreach my $member ($query->members_of($group)) {
+    foreach (@{$member}) {
+      next if (ref $_ eq "HASH");
+      next unless $_ =~ m|^\S+\@\S+$|;
+      push @response, $_ if $query->has_cla($_);
+    }
+  }
+
+  return [ @response ] if @response;
+  send_error('Not found', HTTP_NO_CONTENT);
+};
+
 get '/HasCLA/:id' => sub {
   my $query = OpenSSL::Query->new(omc => config->{omc}, REST => 0);
   my $id = uri_decode(param('id'));

--- a/QueryApp/lib/OpenSSL/Query/ClaDB.pm
+++ b/QueryApp/lib/OpenSSL/Query/ClaDB.pm
@@ -11,6 +11,7 @@ use strict;
 
 package OpenSSL::Query::ClaDB;
 use Carp;
+use Clone qw(clone);
 use Moo;
 use OpenSSL::Query qw(-register-cla OpenSSL::Query::ClaDB -priority 0);
 
@@ -55,6 +56,11 @@ sub has_cla {
   my $starid = '*' . $1;
 
   return exists $self->_cladb->{$id} || exists $self->_cladb->{$starid};
+}
+
+sub list_clas {
+  my $self = shift;
+  return map { clone($_) } sort keys %{$self->_cladb};
 }
 
 1;

--- a/QueryApp/lib/OpenSSL/Query/ClaDB.pm
+++ b/QueryApp/lib/OpenSSL/Query/ClaDB.pm
@@ -41,6 +41,9 @@ sub _build__cladb {
     croak "Duplicate email address: $email"
       if exists $cladb->{$email};
 
+    # Don't include refusals
+    next if $status eq 'R';
+
     $cladb->{$email} = { status => $status, name => $name };
   }
   close $clafh;

--- a/QueryApp/t/query.t
+++ b/QueryApp/t/query.t
@@ -7,7 +7,7 @@ BEGIN { $ENV{DANCER_APPHANDLER} = 'PSGI';}
 
 use strict;
 use warnings;
-use Test::More tests => 20;
+use Test::More tests => 21;
 use Plack::Test;
 use Plack::Util;
 use HTTP::Request::Common;
@@ -175,6 +175,14 @@ subtest 'Request of membership in the group "couchpotatoes"' => sub {
 
 subtest 'Request all existing CLAs' => sub {
   my $res = $test->request( GET '/0/CLAs' );
+  plan tests => 2;
+  ok( $res->is_success, 'Successful request' );
+  note( $res->content );
+  is( $res->code, 200, 'We have content' );
+};
+
+subtest 'Request all existing CLAs for the group "writers"' => sub {
+  my $res = $test->request( GET '/0/Group/writers/CLAs' );
   plan tests => 2;
   ok( $res->is_success, 'Successful request' );
   note( $res->content );

--- a/QueryApp/t/query.t
+++ b/QueryApp/t/query.t
@@ -7,7 +7,7 @@ BEGIN { $ENV{DANCER_APPHANDLER} = 'PSGI';}
 
 use strict;
 use warnings;
-use Test::More tests => 19;
+use Test::More tests => 20;
 use Plack::Test;
 use Plack::Util;
 use HTTP::Request::Common;
@@ -171,6 +171,14 @@ subtest 'Request of membership in the group "couchpotatoes"' => sub {
   ok( $res->is_success, 'Successful request' );
   note( $res->content );
   isnt( $res->code, 200, 'We have no content' );
+};
+
+subtest 'Request all existing CLAs' => sub {
+  my $res = $test->request( GET '/0/CLAs' );
+  plan tests => 2;
+  ok( $res->is_success, 'Successful request' );
+  note( $res->content );
+  is( $res->code, 200, 'We have content' );
 };
 
 1;

--- a/QueryApp/t/query_direct.t
+++ b/QueryApp/t/query_direct.t
@@ -7,7 +7,7 @@ BEGIN { $ENV{DANCER_APPHANDLER} = 'PSGI';}
 
 use strict;
 use warnings;
-use Test::More tests => 14;
+use Test::More tests => 15;
 use Data::Dumper;
 use FindBin;
 
@@ -131,6 +131,13 @@ subtest 'Request of membership in the group "couchpotatoes"' => sub {
   plan tests => 1;
   my @res = $query->members_of( 'couchpotatoes' );
   ok( !@res, 'No members in "couchpotatoes"' );
+  note( @res );
+};
+
+subtest 'Request all existing CLAs' => sub {
+  plan tests => 1;
+  my @res = $query->list_clas();
+  ok( @res, 'We got CLAs' );
   note( @res );
 };
 

--- a/archive-tools/do-release.pl
+++ b/archive-tools/do-release.pl
@@ -169,9 +169,6 @@ if ($do_copy) {
           map { glob("$ftpdir/$_") }
           @glob_patterns;
 
-        mkdir $tomove_oldsrc
-          or die "Couldn't mkdir $tomove_oldsrc : $!"
-          if !-d $tomove_oldsrc;
         mkdir $tomove_oldftp
           or die "Couldn't mkdir $tomove_oldftp : $!"
           if !-d $tomove_oldftp;

--- a/clacheck/README
+++ b/clacheck/README
@@ -8,7 +8,10 @@ Create a GH machine account, get an OAUTH token for it.
 Create a GH webhook that gets pull requests and point it to
 this script.
 
-    ghpass.txt -- A github OAuth token
+    /var/www/clacheck-webhook-token.dat -- A github OAuth token
+
+    /var/www/clacheck-github-sig-secret.dat -- The github webhook
+    authentication secret
 
     clacheck.py -- GitHub hook to check for CLA license
 

--- a/clacheck/clacheck.py
+++ b/clacheck/clacheck.py
@@ -40,10 +40,13 @@ statusbody = """
 }
 """
 
-# A token/secret for authenticating github (incoming)
+# Tokens/secrets: one for authenticating github (incoming) and one for
+# the authentication of this client (outgoing)
 secrets_location=env.get('OSSL_SECRETS', '/var/www')
 incoming_token = open(os.path.join(secrets_location,
                                    'clacheck-github-sig-secret.dat')).read().strip()
+outgoing_token = open(os.path.join(secrets_location,
+                                   'clacheck-webhook-token.dat')).read().strip()
 
 def url_split(url):
     m = URLpattern.match(url)
@@ -51,10 +54,9 @@ def url_split(url):
 
 def update_status(pr, state, description):
     d = { 'state': state, 'description': description }
-    token = open('../ghpass.txt').read().strip() #<EDIT> password file
     headers = {
-            'Authorization': 'token ' + token,
-            'User-Agent': 'richsalz', #<EDIT> some other name
+            'Authorization': 'token ' + outgoing_token,
+            'User-Agent': 'openssl-machine',
             'Content-Type': 'application/json; charset=utf-8',
             'Accept': 'application/json',
             }


### PR DESCRIPTION
- do-release.pl: don't copy tarballs to /var/www/openssl/source any more
- OpenSSL-Query, QueryApp: add DB library function list_clas to extract all CLAs
- OpenSSL-Query, QueryApp: add REST API and library function list_clas to extract all CLAs
- QueryApp: add REST API extract all CLAs for a specific group
- QueryApp: Don't include refusals in the collected CLA data
- QueryApp: Version bump
- OpenSSL-Query: Version bump
- Add authentication of incoming github requests
- Move the outgoing token to the same location as the incoming token
- Document the changed secret files
- "Missed a spot!"
- Convert clacheck/clacheck.py to Python 3
